### PR TITLE
Support items with a specific size and shape

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,6 +64,14 @@ import SortableGrid from 'react-native-sortable-grid'
 
   How many items should be placed on one row
 
+ -  ``` itemWidth ``` **Number**
+
+  If set, itemsPerRow will be calculated to fit items of this size
+
+ -  ``` itemHeight ``` **Number**
+
+  When used together with itemsPerRow, sets the size of a block to something other than the default square
+
  -  ``` dragActivationTreshold ``` **Number**
 
   How long must the user hold the press on the block until it becomes active and can be dragged (milliseconds)

--- a/index.js
+++ b/index.js
@@ -49,7 +49,7 @@ class SortableGrid extends Component {
     render = () =>
       <Animated.View
         style={ this._getGridStyle() }
-        onLayout={ this.assessGridSize }
+        onLayout={this.assessGridSize}
       >
         { this.state.gridLayout &&
           this.items.map( (item, key) =>
@@ -86,6 +86,9 @@ class SortableGrid extends Component {
     this.dragPosition      = null
     this.activeBlockOffset = null
     this.blockWidth        = null
+    this.blockHeight       = null
+    this.itemWidth         = null
+    this.itemHeight         = null
     this.gridHeightTarget  = null
     this.ghostBlocks       = []
     this.itemOrder         = []
@@ -104,6 +107,7 @@ class SortableGrid extends Component {
       startDragWiggle: new Animated.Value(0),
       activeBlock: null,
       blockWidth: null,
+      blockHeight: null,
       gridHeight: new Animated.Value(0),
       blockPositionsSetCount: 0,
       deleteModeOn: false,
@@ -151,7 +155,7 @@ class SortableGrid extends Component {
 
       if (dx != 0 || dy != 0) this.initialDragDone = true
 
-      let yChokeAmount = Math.max(0, (this.activeBlockOffset.y + moveY) - (this.state.gridLayout.height - this.blockWidth))
+      let yChokeAmount = Math.max(0, (this.activeBlockOffset.y + moveY) - (this.state.gridLayout.height - this.blockHeight))
       let xChokeAmount = Math.max(0, (this.activeBlockOffset.x + moveX) - (this.state.gridLayout.width - this.blockWidth))
       let yMinChokeAmount = Math.min(0, this.activeBlockOffset.y + moveY)
       let xMinChokeAmount = Math.min(0, this.activeBlockOffset.x + moveX)
@@ -275,11 +279,21 @@ class SortableGrid extends Component {
   }
 
   assessGridSize = ({nativeEvent}) => {
-    this.blockWidth = nativeEvent.layout.width / this.itemsPerRow
+    console.log("Calculating grid size");
+    if (this.props.itemWidth && this.props.itemWidth < nativeEvent.layout.width) {
+      this.itemsPerRow = Math.floor(nativeEvent.layout.width / this.props.itemWidth)
+      this.blockWidth = nativeEvent.layout.width / this.itemsPerRow
+      this.blockHeight = this.props.itemHeight || this.blockWidth
+    }
+    else {
+      this.blockWidth = nativeEvent.layout.width / this.itemsPerRow
+      this.blockHeight = this.blockWidth
+    }
     if (this.state.gridLayout != nativeEvent.layout) {
       this.setState({
         gridLayout: nativeEvent.layout,
-        blockWidth: this.blockWidth
+        blockWidth: this.blockWidth,
+        blockHeight: this.blockHeight
       })
     }
   }
@@ -315,7 +329,7 @@ class SortableGrid extends Component {
   getNextBlockCoordinates = () => {
     let blockWidth = this.state.blockWidth
     let placeOnRow = this.items.length % this.itemsPerRow
-    let y = blockWidth * Math.floor(this.items.length / this.itemsPerRow)
+    let y = blockHeight * Math.floor(this.items.length / this.itemsPerRow)
     let x = placeOnRow * blockWidth
     return { x, y }
   }
@@ -324,9 +338,10 @@ class SortableGrid extends Component {
     this.ghostBlocks = []
     this.reAssessGridRows()
     let blockWidth = this.state.blockWidth
+    let blockHeight = this.state.blockHeight
     let fullGridItemCount = this.rows * this.itemsPerRow
     let ghostBlockCount = fullGridItemCount - this.items.length
-    let y = blockWidth * (this.rows - 1)
+    let y = blockHeight * (this.rows - 1)
     let initialX =  blockWidth * (this.itemsPerRow - ghostBlockCount)
 
     for (let i = 0; i < ghostBlockCount; ++i) {
@@ -412,7 +427,7 @@ class SortableGrid extends Component {
         this.items.forEach( (item, order) => {
           let blockIndex = _.findIndex(this.itemOrder, item => item.order === order)
           let x = (order * this.state.blockWidth) % (this.itemsPerRow * this.state.blockWidth)
-          let y = Math.floor(order / this.itemsPerRow) * this.state.blockWidth
+          let y = Math.floor(order / this.itemsPerRow) * this.state.blockHeight
           this.state.blockPositions[blockIndex].origin = {x, y}
           this.animateBlockMove(blockIndex, {x, y})
         })
@@ -427,7 +442,7 @@ class SortableGrid extends Component {
   }
 
   _animateGridHeight = () => {
-    this.gridHeightTarget = this.rows * this.state.blockWidth
+    this.gridHeightTarget = this.rows * this.state.blockHeight
     if (this.gridHeightTarget === this.state.gridLayout.height || this.state.gridLayout.height === 0)
       this.state.gridHeight.setValue(this.gridHeightTarget)
     else if (this.state.gridHeight._value !== this.gridHeightTarget) {
@@ -536,7 +551,7 @@ class SortableGrid extends Component {
 
   _getImageDeleteIconStyle = (key) => [
     { position: 'absolute',
-      top: this.state.blockWidth/2 - 15,
+      top: this.state.blockHeight/2 - 15,
       left: this.state.blockWidth/2 - 15,
       width: 30,
       height: 30,
@@ -556,7 +571,7 @@ class SortableGrid extends Component {
 
   _getBlockStyle = (key) => [
     { width: this.state.blockWidth,
-      height: this.state.blockWidth,
+      height: this.state.blockHeight,
       justifyContent: 'center' },
     this._blockPositionsSet() && (this.initialDragDone || this.state.deleteModeOn) &&
     { position: 'absolute',

--- a/index.js
+++ b/index.js
@@ -328,6 +328,7 @@ class SortableGrid extends Component {
 
   getNextBlockCoordinates = () => {
     let blockWidth = this.state.blockWidth
+    let blockHeight = this.state.blockHeight
     let placeOnRow = this.items.length % this.itemsPerRow
     let y = blockHeight * Math.floor(this.items.length / this.itemsPerRow)
     let x = placeOnRow * blockWidth


### PR DESCRIPTION
This adds the optional properties itemWidth and itemHeight which allow you to specify the ideal size/shape of an item rather than always using a square based on itemsPerRow.