### PR TITLE
Allow children to mark themselves as inactive

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,6 +106,9 @@ import SortableGrid from 'react-native-sortable-grid'
 
   Function that is executed when the block is double tapped within a timeframe of ```doubleTapTreshold``` (default 150ms). Assigning this will delay the execution of ```onTap```. Omitting this will cause all taps to be handled as single taps, regardless of their frequency.
 
+ - ``` inactive ``` **Boolean**
+
+Flag to mark a child node as being inactive. If set, no touch events will be fired when users interact with the node.
 
 ## onDragRelease return value looks like this:
 

--- a/index.js
+++ b/index.js
@@ -29,8 +29,8 @@ class Block extends Component {
       <TouchableWithoutFeedback
         style          = {{ flex: 1 }}
         delayLongPress = { this.props.delayLongPress }
-        onLongPress    = { this.props.onLongPress }
-        onPress        = { this.props.onPress }>
+        onLongPress    = { () => this.props.inactive || this.props.onLongPress() }
+        onPress        = { () => this.props.inactive || this.props.onPress() }>
 
           <View style={styles.itemImageContainer}>
             <View style={ this.props.itemWrapperStyle }>
@@ -63,6 +63,7 @@ class SortableGrid extends Component {
               onPress = { this.handleTap(item.props) }
               itemWrapperStyle = { this._getItemWrapperStyle(key) }
               deletionView = { this._getDeletionView(key) }
+              inactive = { item.props.inactive }
             >
               {item}
             </Block>


### PR DESCRIPTION
It's occasionally useful to be able to have cells that don't respond to user
interactions, like if you're trying to pad out a grid with "empty" cells. In
that case, we should let consuming code mark child nodes as `inactive`, which
will disable the touch handling for the block.

This is an alternate implementation to the one proposed in #23. I believe they both try to solve the same problem, but in different ways.